### PR TITLE
Switch to scikit-build-core and libbson 2.x for pymongoarrow 1.15.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,6 @@
+set "MONGO_NO_COPY_LIBBSON=1"
+set "LIBBSON_INSTALL_DIR=%LIBRARY_PREFIX%"
+set "MONGO_CREATE_LIBARROW_SYMLINKS=0"
+
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vvv
+if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eux
+
+export MONGO_NO_COPY_LIBBSON=1
+export LIBBSON_INSTALL_DIR="${PREFIX}"
+export MONGO_CREATE_LIBARROW_SYMLINKS=0
+export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"
+export CMAKE_GENERATOR=Ninja
+
+# find_program(cython) in CMakeLists.txt picks up the host-prefix cython
+# script, whose shebang (padded for conda-build's later prefix replacement)
+# exceeds Linux's shebang length limit and silently runs under the wrong
+# interpreter. Shim it with a short script that invokes cython as a module
+# instead, and put it first on PATH.
+mkdir -p "${SRC_DIR}/_cmake_shims"
+cat > "${SRC_DIR}/_cmake_shims/cython" <<SHIM
+#!/bin/sh
+exec "${PYTHON}" -m cython "\$@"
+SHIM
+chmod +x "${SRC_DIR}/_cmake_shims/cython"
+export PATH="${SRC_DIR}/_cmake_shims:${PATH}"
+
+"${PYTHON}" -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,13 +11,15 @@ export CMAKE_GENERATOR=Ninja
 # script, whose shebang (padded for conda-build's later prefix replacement)
 # exceeds Linux's shebang length limit and silently runs under the wrong
 # interpreter. Shim it with a short script that invokes cython as a module
-# instead, and put it first on PATH.
+# instead. scikit-build-core sets CMAKE_PROGRAM_PATH to the prefix bin dirs,
+# which find_program() searches before PATH, so point CYTHON_EXECUTABLE at
+# the shim directly rather than relying on PATH order.
 mkdir -p "${SRC_DIR}/_cmake_shims"
 cat > "${SRC_DIR}/_cmake_shims/cython" <<SHIM
 #!/bin/sh
 exec "${PYTHON}" -m cython "\$@"
 SHIM
 chmod +x "${SRC_DIR}/_cmake_shims/cython"
-export PATH="${SRC_DIR}/_cmake_shims:${PATH}"
+export CMAKE_ARGS="${CMAKE_ARGS:-} -DCYTHON_EXECUTABLE=${SRC_DIR}/_cmake_shims/cython"
 
 "${PYTHON}" -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,25 +28,6 @@ build:
   # py3.14t (free-threaded) only supported from v24 onwards
   skip: true  # [is_freethreading]
   {% endif %}
-  script:
-    - set eux  # [unix]
-    - export MONGO_NO_COPY_LIBBSON=1              # [unix]
-    - export LIBBSON_INSTALL_DIR="${PREFIX}"      # [unix]
-    - export MONGO_CREATE_LIBARROW_SYMLINKS=0     # [unix]
-    - export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"  # [unix]
-    - export CMAKE_GENERATOR=Ninja                # [unix]
-    # find_program(cython) picks up the host-prefix script, whose shebang
-    # (padded for conda-build's prefix replacement) exceeds Linux's shebang
-    # length limit and silently runs under the wrong interpreter. Shim it
-    # with a short script that invokes cython as a module instead.
-    - mkdir -p "${SRC_DIR}/_cmake_shims"                                    # [unix]
-    - printf '#!/bin/sh\nexec "%s" -m cython "$@"\n' "{{ PYTHON }}" > "${SRC_DIR}/_cmake_shims/cython"  # [unix]
-    - chmod +x "${SRC_DIR}/_cmake_shims/cython"   # [unix]
-    - export PATH="${SRC_DIR}/_cmake_shims:${PATH}"  # [unix]
-    - set MONGO_NO_COPY_LIBBSON=1                 # [win]
-    - set "LIBBSON_INSTALL_DIR=%LIBRARY_PREFIX%"  # [win]
-    - set MONGO_CREATE_LIBARROW_SYMLINKS=0         # [win]
-    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,10 +35,17 @@ build:
     - export MONGO_CREATE_LIBARROW_SYMLINKS=0     # [unix]
     - export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"  # [unix]
     - export CMAKE_GENERATOR=Ninja                # [unix]
+    # find_program(cython) picks up the host-prefix script, whose shebang
+    # (padded for conda-build's prefix replacement) exceeds Linux's shebang
+    # length limit and silently runs under the wrong interpreter. Shim it
+    # with a short script that invokes cython as a module instead.
+    - mkdir -p "${SRC_DIR}/_cmake_shims"                                    # [unix]
+    - printf '#!/bin/sh\nexec "%s" -m cython "$@"\n' "{{ PYTHON }}" > "${SRC_DIR}/_cmake_shims/cython"  # [unix]
+    - chmod +x "${SRC_DIR}/_cmake_shims/cython"   # [unix]
+    - export PATH="${SRC_DIR}/_cmake_shims:${PATH}"  # [unix]
     - set MONGO_NO_COPY_LIBBSON=1                 # [win]
     - set "LIBBSON_INSTALL_DIR=%LIBRARY_PREFIX%"  # [win]
     - set MONGO_CREATE_LIBARROW_SYMLINKS=0         # [win]
-    - set CMAKE_GENERATOR=Ninja                    # [win]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,9 +34,11 @@ build:
     - export LIBBSON_INSTALL_DIR="${PREFIX}"      # [unix]
     - export MONGO_CREATE_LIBARROW_SYMLINKS=0     # [unix]
     - export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"  # [unix]
+    - export CMAKE_GENERATOR=Ninja                # [unix]
     - set MONGO_NO_COPY_LIBBSON=1                 # [win]
     - set "LIBBSON_INSTALL_DIR=%LIBRARY_PREFIX%"  # [win]
     - set MONGO_CREATE_LIBARROW_SYMLINKS=0         # [win]
+    - set CMAKE_GENERATOR=Ninja                    # [win]
     - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pymongoarrow" %}
-{% set version = "1.14.0" %}
+{% set version = "1.15.0" %}
 
 # just to be able to use libarrow in jinja below
 {% if libarrow is undefined %}
@@ -12,10 +12,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/pymongoarrow/pymongoarrow-{{ version }}.tar.gz
-  sha256: f20fd2a62d5355670bfa4f36df7275a437e4c36c89b785e664852415917ec408
+  sha256: 155a0a4491f5c88611c218038b7378697ed87e4d08e3915c0facae238a39c4e8
 
 build:
-  number: 2
+  number: 0
   {% if libarrow.split(".")[0]|int < 18 %}
   # py3.13 only supported from v18 onwards
   skip: true  # [py>=313]
@@ -30,27 +30,26 @@ build:
   {% endif %}
   script:
     - set eux  # [unix]
-    - export MONGO_NO_COPY_LIBARROW=1             # [unix]
-    - export MONGO_LIBARROW_DIR="${PREFIX}/lib"   # [unix]
     - export MONGO_NO_COPY_LIBBSON=1              # [unix]
     - export LIBBSON_INSTALL_DIR="${PREFIX}"      # [unix]
-    - export MONGO_CREATE_LIBARROW_SYMLINKS=""    # [unix]
-    - export MONGO_ADD_GLIBCXX_OVERRIDE=""        # [unix]
-    - set MONGO_NO_COPY_LIBARROW=1                # [win]
-    - set "MONGO_LIBARROW_DIR=%LIBRARY_LIB%"      # [win]
+    - export MONGO_CREATE_LIBARROW_SYMLINKS=0     # [unix]
+    - export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"  # [unix]
     - set MONGO_NO_COPY_LIBBSON=1                 # [win]
     - set "LIBBSON_INSTALL_DIR=%LIBRARY_PREFIX%"  # [win]
-    - {{ PYTHON }} -m pip install . --no-deps -vvv
+    - set MONGO_CREATE_LIBARROW_SYMLINKS=0         # [win]
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:
   build:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
+    - cython >=3.0                           # [build_platform != target_platform]
     - libarrow                               # [build_platform != target_platform]
     - pyarrow                                # [build_platform != target_platform]
     - libbson                                # [build_platform != target_platform]
     - pkg-config                             # [build_platform != target_platform]
+    - cmake >=3.17
+    - ninja
     - pip
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
@@ -60,17 +59,18 @@ requirements:
     - python
     - libarrow
     - pyarrow
-    - cython >=0.29
-    - libbson >=1,<2
+    - cython >=3.0
+    - libbson >=2.0.1,<3
     - numpy  # for headers
     - pip
     - pkg-config
-    - setuptools >=70,<72.2
+    - scikit-build-core >=0.10
 
   run:
-    - pymongo >=3.11,<5
+    - pymongo >=4.4,<5
     - pyarrow
-    - packaging
+    - numpy
+    - packaging >=23.2
     - python
 
 test:


### PR DESCRIPTION
## Summary
pymongoarrow 1.15.0 dropped its setuptools build for scikit-build-core and now requires libbson >=2.0.1, which just became available on conda-forge (was blocked on that until now).

Closes https://github.com/conda-forge/pymongoarrow-feedstock/pull/87

## Changes
- Bump to pymongoarrow 1.15.0; switch host build backend from `setuptools` to `scikit-build-core`, `libbson >=1,<2` to `>=2.0.1,<3`
- Add `cmake`/`ninja` build deps; select Ninja as the generator on Linux (conda-forge's Linux images have no `make`)
- Move build logic into `recipe/build.sh`/`recipe/bld.bat`
- Work around a Linux-only Cython lookup bug (padded-prefix shebang breaks `find_program`'s resolution of `cython`) with a small wrapper script
- Fix stale runtime deps: `pymongo >=4.4,<5`, `packaging >=23.2`, add missing `numpy`

## Testing
All CI variants (linux_64, osx_64, win_64 × Python 3.10-3.14 × libarrow 21-24) pass.

## AI disclosure
Authored by Claude Code (Claude Sonnet 5), iterating against this PR's CI until all platforms passed. Pending maintainer review.